### PR TITLE
Fix implicit conversion warning

### DIFF
--- a/FoundationExtension/NSArray.m
+++ b/FoundationExtension/NSArray.m
@@ -17,7 +17,7 @@
 }
 
 - (BOOL)hasIndex:(NSUInteger)index {
-    return index <r self.count;
+    return index < self.count;
 }
 
 @end


### PR DESCRIPTION
We can cast since arc4random_uniform anyway accepts only u_int32_t.
