### PR TITLE
Fix to avoid private method warning from appstore.

### DIFF
--- a/FoundationExtension/NSTimer.h
+++ b/FoundationExtension/NSTimer.h
@@ -65,7 +65,7 @@ typedef void (^NSATimerBlock)();
  *  @brief Fired event.
  *  @param timer Fired timer.
  */
-- (void)timerDidFire:(NSTimer *)timer;
+- (void)timerHasFired:(NSTimer *)timer;
 
 /*!
  *  @brief Timer should repeat or not.
@@ -76,9 +76,13 @@ typedef void (^NSATimerBlock)();
 
 @optional
 /*!
- *  @brief Use timerDidFire:. Deprecated by name collision with private method.
+ *  @brief Use timerHasFired:. Deprecated by name collision with private method.
  */
 - (void)timerFired:(NSTimer *)timer __deprecated;
+/*!
+ *  @brief Use timerHasFired:. Deprecated by name collision with private method.
+ */
+- (void)timerDidFire:(NSTimer *)timer __deprecated;
 
 @end
 

--- a/FoundationExtension/NSTimer.m
+++ b/FoundationExtension/NSTimer.m
@@ -37,7 +37,7 @@
 
 static void NSTimerDelegateCallback(CFRunLoopTimerRef timer, void *info) {
     id<NSTimerDelegate> delegate = info;
-    [delegate timerDidFire:(NSTimer *)timer];
+    [delegate timerHasFired:(NSTimer *)timer];
     if (![delegate timerShouldRepeat:(NSTimer *)timer]) {
         CFRunLoopTimerInvalidate(timer);
     };

--- a/UIKitExtensionTestApp/UITMasterViewController.m
+++ b/UIKitExtensionTestApp/UITMasterViewController.m
@@ -17,7 +17,7 @@
 
 @implementation UITMasterViewController
 
-- (void)timerDidFire:(NSTimer *)timer {
+- (void)timerHasFired:(NSTimer *)timer {
     self.title = [[NSDate date] description];
 }
 


### PR DESCRIPTION
Same issue as:  https://github.com/youknowone/FoundationExtension/commit/d9dfa780bf466ec9a0932df366e205d9e200877f

Received a non-public selector warning for timerDidFire when validating for the App Store. Newly chosen name  in that commit again seems to be clashing.
