### PR TITLE
fix 64-bit

### DIFF
--- a/FoundationExtension/NSObject.m
+++ b/FoundationExtension/NSObject.m
@@ -55,12 +55,12 @@
 
 - (id)performSelector:(SEL)sel withObject:(id)obj1 withObject:(id)obj2 withObject:(id)obj3 {
     if (!sel) [self doesNotRecognizeSelector:sel];
-    return objc_msgSend(self, sel, obj1, obj2, obj3);
+    return ((id(*)(id, SEL, id, id, id))objc_msgSend)(self, sel, obj1, obj2, obj3);
 }
 
 - (id)performSelector:(SEL)sel withObject:(id)obj1 withObject:(id)obj2 withObject:(id)obj3 withObject:(id)obj4 {
     if (!sel) [self doesNotRecognizeSelector:sel];
-    return objc_msgSend(self, sel, obj1, obj2, obj3, obj4);
+    return ((id(*)(id, SEL, id, id, id, id))objc_msgSend)(self, sel, obj1, obj2, obj3, obj4);
 }
 
 - (id)associatedObjectForKey:(void *)key {


### PR DESCRIPTION
Manual casting is necessary for 64-bit to work correctly. As it was, it will work on a simulator but not on a device.

see: http://stackoverflow.com/questions/19507456/sudzc-arc-version-objc-msgsend-call-causes-exc-bad-access-using-64-bit-archite

and: https://developer.apple.com/library/ios/documentation/General/Conceptual/CocoaTouch64BitGuide/ConvertingYourAppto64-Bit/ConvertingYourAppto64-Bit.html
